### PR TITLE
Add llvm patch to fix error GVN on shared memory load.

### DIFF
--- a/third_party/llvm/0001-AICompiler-llvm-patches.patch
+++ b/third_party/llvm/0001-AICompiler-llvm-patches.patch
@@ -1,0 +1,190 @@
+From 211b789c9e568bf873221981378ba6f6eb4d7cc0 Mon Sep 17 00:00:00 2001
+From: "ZHENG,Zhen" <zzchman@gmail.com>
+Date: Wed, 8 Dec 2021 20:39:06 +0800
+Subject: [PATCH] AICompiler llvm patches.
+
+1. [mlir][ROCm] Add shfl.sync.bfly lowering.
+2. [llvm][nvptx] Fix error GVN on shared memory load.
+---
+ llvm/lib/Transforms/Scalar/GVN.cpp            | 53 ++++++++++++++
+ mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td  | 12 ++++
+ .../ROCDL/ROCDLToLLVMIRTranslation.cpp        | 71 +++++++++++++++++++
+ 3 files changed, 136 insertions(+)
+
+diff --git a/llvm/lib/Transforms/Scalar/GVN.cpp b/llvm/lib/Transforms/Scalar/GVN.cpp
+index 16368aec7c3f..d2f54dca486a 100644
+--- a/llvm/lib/Transforms/Scalar/GVN.cpp
++++ b/llvm/lib/Transforms/Scalar/GVN.cpp
+@@ -1002,6 +1002,40 @@ static void reportMayClobberedLoad(LoadInst *Load, MemDepResult DepInfo,
+   ORE->emit(R);
+ }
+ 
++/// Get instructions between two given instructions.
++static void collectInstructionsInBetween(
++    Instruction *StartInst, const Instruction *EndInst,
++    llvm::SmallPtrSetImpl<Instruction *> &InBetweenInsts) {
++  assert(InBetweenInsts.empty() && "Expecting InBetweenInsts to be empty");
++
++  /// Get the next instructions of \p I, and push them to \p WorkList.
++  auto getNextInsts = [](Instruction *I,
++                         llvm::SmallPtrSetImpl<Instruction *> &WorkList) {
++    if (Instruction *NextInst = I->getNextNode())
++      WorkList.insert(NextInst);
++    else {
++      assert(I->isTerminator() && "Expecting a terminator instruction");
++      for (BasicBlock *Succ : successors(I))
++        WorkList.insert(&Succ->front());
++    }
++  };
++
++  llvm::SmallPtrSet<Instruction *, 10> WorkList;
++  getNextInsts(StartInst, WorkList);
++  while (!WorkList.empty()) {
++    Instruction *CurInst = *WorkList.begin();
++    WorkList.erase(CurInst);
++
++    if (CurInst == EndInst)
++      continue;
++
++    if (!InBetweenInsts.insert(CurInst).second)
++      continue;
++
++    getNextInsts(CurInst, WorkList);
++  }
++}
++
+ bool GVN::AnalyzeLoadAvailability(LoadInst *Load, MemDepResult DepInfo,
+                                   Value *Address, AvailableValue &Res) {
+   assert((DepInfo.isDef() || DepInfo.isClobber()) &&
+@@ -1011,6 +1045,25 @@ bool GVN::AnalyzeLoadAvailability(LoadInst *Load, MemDepResult DepInfo,
+   const DataLayout &DL = Load->getModule()->getDataLayout();
+ 
+   Instruction *DepInst = DepInfo.getInst();
++  // Deal with shared memory load of nvptx. Cannot forward if there is a call
++  // between the two instructions.
++  const std::string &TT = Load->getModule()->getTargetTriple();
++  if ((TT.find("nvptx") != std::string::npos) &&
++      (Load->getPointerAddressSpace() == 3)) {
++    if (dyn_cast<StoreInst>(DepInst) || dyn_cast<LoadInst>(DepInst)) {
++      SmallPtrSet<Instruction *, 10> InBetweenInsts;
++      collectInstructionsInBetween(DepInst, Load, InBetweenInsts);
++      for (auto Inst : InBetweenInsts) {
++        if (CallInst *CallI = dyn_cast<CallInst>(Inst)) {
++          // Thread-block level barrier may be called directly or indirectly.
++          // e.g. direct call:
++          //     call void @llvm.nvvm.barrier0()
++          return false;
++        }
++      }
++    }
++  }
++
+   if (DepInfo.isClobber()) {
+     // If the dependence is to a store that writes to a superset of the bits
+     // read by the load, we can extract the bits we need for the load from the
+diff --git a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+index 1b45e5144263..d41569314696 100644
+--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
++++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+@@ -189,4 +189,16 @@ def ROCDL_MubufStoreOp :
+   }];
+ }
+ 
++def ROCDL_ShflBflyOp :
++  ROCDL_Op<"shfl.sync.bfly">,
++  Results<(outs LLVM_Type:$res)>,
++  Arguments<(ins LLVM_Type:$active_mask,
++                 LLVM_Type:$val,
++                 LLVM_Type:$offset,
++                 LLVM_Type:$mask_and_clamp)> {
++  string llvmBuilder = [{
++      $res = createAMDGPUShflBfly($val, $offset, $mask_and_clamp, builder);
++  }];
++}
++
+ #endif // ROCDLIR_OPS
+diff --git a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
+index 8a3470ce80aa..4e35350b615b 100644
+--- a/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
++++ b/mlir/lib/Target/LLVMIR/Dialect/ROCDL/ROCDLToLLVMIRTranslation.cpp
+@@ -41,6 +41,77 @@ static llvm::Value *createDeviceFunctionCall(llvm::IRBuilderBase &builder,
+   return builder.CreateCall(fn, ArrayRef<llvm::Value *>(fn_op0));
+ }
+ 
++/// Lowers a shuffle to the corresponding ROCDL op.
++/// Ref:
++/// https://github.com/ROCm-Developer-Tools/hipamd/blob/master/include/hip/amd_detail/amd_device_functions.h
++/// ```
++/// __device__
++/// inline
++/// int __shfl_xor(int var, int offset, int width = warpSize) {
++///     int self = __lane_id();
++///     int index = self^offset;
++///     index = index >= ((self+width)&~(width-1))?self:index;
++///     return __builtin_amdgcn_ds_bpermute(index<<2, var);
++/// }```
++///
++/// Lowers a shuffle to the corresponding ROCDL op.
++///
++/// maskAndClamp (specifying the highest lane which participates in the
++/// shuffle).
++///
++///     %one = llvm.constant(1 : i32) : i32
++///     %two = llvm.constant(2 : i32) : i32
++///     %width = llvm.add %mask_and_clamp, %one : i32
++///     %self = @call __ockl_lane_u32() : i32
++///     %index = llvm.xor %self, %offset : i32
++///     %self_add = llvm.add %self, %width : i32
++///     %bit_rvs_mask = llvm.not %mask_and_clamp: i32
++///     %upper_bound = llvm.and %self_add, %bit_rvs_mask: i32
++///     %cond_cmp = llvm.icmp %index, %upper_bound { predicate = 'sge' }: i1
++///     %dst_index = llvm.select %cond_cmp, %self, %index : i32
++///     %shl_index = llvm.shl %dst_index, %two : i32
++///     @call __amdgcn_ds_bpermute(shl_index, %var)
++///
++static llvm::Value *createAMDGPUShflBfly(llvm::Value *value,
++                                         llvm::Value *offset,
++                                         llvm::Value *mask_and_clamp,
++                                         llvm::IRBuilderBase &builder) {
++
++  // CHECK_EQ(value->getType()->getPrimitiveSizeInBits(), 32);
++  llvm::Module *module = builder.GetInsertBlock()->getModule();
++  auto valueTy = value->getType();
++  auto int32Type = builder.getInt32Ty();
++
++  auto function_type = llvm::FunctionType::get(int32Type, false);
++  auto fn = dyn_cast<llvm::Function>(
++      module->getOrInsertFunction("__ockl_lane_u32", function_type)
++          .getCallee());
++  auto self = builder.CreateCall(fn);
++
++  auto one = builder.getInt32(1);
++  auto two = builder.getInt32(2);
++  auto width = builder.CreateAdd(mask_and_clamp, one);
++  auto index = builder.CreateXor(self, offset);
++  auto self_add = builder.CreateAdd(self, width);
++  auto bitnot_mask = builder.CreateNot(mask_and_clamp);
++  auto upper_bound = builder.CreateAnd(self_add, bitnot_mask);
++  auto cond_cmp = builder.CreateICmp(llvm::CmpInst::Predicate::ICMP_SGE, index,
++                                     upper_bound);
++  auto dst_index = builder.CreateSelect(cond_cmp, self, index);
++  auto shl_index = builder.CreateShl(dst_index, two);
++
++  auto i32_value = builder.CreateBitCast(value, int32Type);
++
++  auto function_type2 =
++      llvm::FunctionType::get(int32Type, {int32Type, int32Type}, false);
++  auto fn2 = dyn_cast<llvm::Function>(
++      module->getOrInsertFunction("__amdgcn_ds_bpermute", function_type2)
++          .getCallee());
++  auto shfl_value = builder.CreateCall(fn2, {shl_index, i32_value});
++
++  return builder.CreateBitCast(shfl_value, valueTy);
++}
++
+ namespace {
+ /// Implementation of the dialect interface that converts operations belonging
+ /// to the ROCDL dialect to LLVM IR.
+-- 
+2.24.3 (Apple Git-128)
+

--- a/third_party/llvm/0001-llvm-nvptx-Fix-error-GVN-on-shared-memory-load.patch
+++ b/third_party/llvm/0001-llvm-nvptx-Fix-error-GVN-on-shared-memory-load.patch
@@ -1,0 +1,83 @@
+From 43aea3fe12e4243246d8f38e4844381c9193d517 Mon Sep 17 00:00:00 2001
+From: "ZHENG,Zhen" <zzchman@gmail.com>
+Date: Wed, 8 Dec 2021 20:39:06 +0800
+Subject: [PATCH] [llvm][nvptx] Fix error GVN on shared memory load.
+
+---
+ llvm/lib/Transforms/Scalar/GVN.cpp | 53 ++++++++++++++++++++++++++++++
+ 1 file changed, 53 insertions(+)
+
+diff --git a/llvm/lib/Transforms/Scalar/GVN.cpp b/llvm/lib/Transforms/Scalar/GVN.cpp
+index 16368aec7c3f..d2f54dca486a 100644
+--- a/llvm/lib/Transforms/Scalar/GVN.cpp
++++ b/llvm/lib/Transforms/Scalar/GVN.cpp
+@@ -1002,6 +1002,40 @@ static void reportMayClobberedLoad(LoadInst *Load, MemDepResult DepInfo,
+   ORE->emit(R);
+ }
+ 
++/// Get instructions between two given instructions.
++static void collectInstructionsInBetween(
++    Instruction *StartInst, const Instruction *EndInst,
++    llvm::SmallPtrSetImpl<Instruction *> &InBetweenInsts) {
++  assert(InBetweenInsts.empty() && "Expecting InBetweenInsts to be empty");
++
++  /// Get the next instructions of \p I, and push them to \p WorkList.
++  auto getNextInsts = [](Instruction *I,
++                         llvm::SmallPtrSetImpl<Instruction *> &WorkList) {
++    if (Instruction *NextInst = I->getNextNode())
++      WorkList.insert(NextInst);
++    else {
++      assert(I->isTerminator() && "Expecting a terminator instruction");
++      for (BasicBlock *Succ : successors(I))
++        WorkList.insert(&Succ->front());
++    }
++  };
++
++  llvm::SmallPtrSet<Instruction *, 10> WorkList;
++  getNextInsts(StartInst, WorkList);
++  while (!WorkList.empty()) {
++    Instruction *CurInst = *WorkList.begin();
++    WorkList.erase(CurInst);
++
++    if (CurInst == EndInst)
++      continue;
++
++    if (!InBetweenInsts.insert(CurInst).second)
++      continue;
++
++    getNextInsts(CurInst, WorkList);
++  }
++}
++
+ bool GVN::AnalyzeLoadAvailability(LoadInst *Load, MemDepResult DepInfo,
+                                   Value *Address, AvailableValue &Res) {
+   assert((DepInfo.isDef() || DepInfo.isClobber()) &&
+@@ -1011,6 +1045,25 @@ bool GVN::AnalyzeLoadAvailability(LoadInst *Load, MemDepResult DepInfo,
+   const DataLayout &DL = Load->getModule()->getDataLayout();
+ 
+   Instruction *DepInst = DepInfo.getInst();
++  // Deal with shared memory load of nvptx. Cannot forward if there is a call
++  // between the two instructions.
++  const std::string &TT = Load->getModule()->getTargetTriple();
++  if ((TT.find("nvptx") != std::string::npos) &&
++      (Load->getPointerAddressSpace() == 3)) {
++    if (dyn_cast<StoreInst>(DepInst) || dyn_cast<LoadInst>(DepInst)) {
++      SmallPtrSet<Instruction *, 10> InBetweenInsts;
++      collectInstructionsInBetween(DepInst, Load, InBetweenInsts);
++      for (auto Inst : InBetweenInsts) {
++        if (CallInst *CallI = dyn_cast<CallInst>(Inst)) {
++          // Thread-block level barrier may be called directly or indirectly.
++          // e.g. direct call:
++          //     call void @llvm.nvvm.barrier0()
++          return false;
++        }
++      }
++    }
++  }
++
+   if (DepInfo.isClobber()) {
+     // If the dependence is to a store that writes to a superset of the bits
+     // read by the load, we can extract the bits we need for the load from the
+-- 
+2.24.3 (Apple Git-128)
+

--- a/third_party/llvm/workspace.bzl
+++ b/third_party/llvm/workspace.bzl
@@ -16,5 +16,5 @@ def repo(name):
             "https://github.com/llvm/llvm-project/archive/{commit}.tar.gz".format(commit = LLVM_COMMIT),
         ],
         build_file = "//third_party/llvm:BUILD.bazel",
-        patch_file = "//third_party/llvm:0001-mlir-ROCm-Add-shfl.sync.bfly-lowering.patch",
+        patch_file = "//third_party/llvm:0001-AICompiler-llvm-patches.patch",
     )


### PR DESCRIPTION
Add a new llvm patch to fix error GNV optimization. The previous patch is merged into the new one as it only supports one patch file.