### PR TITLE
fix casting failed if shape is i32

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
@@ -1763,16 +1763,8 @@ struct DynamicIotaBroadcast : public OpRewritePattern<DynamicIotaOp> {
 
     auto iotaDimension = iota.iota_dimension();
     auto iotaDimensionInt = iotaDimension;
-
-    auto convertedShape = rewriter.create<arith::IndexCastOp>(
-        iota.getLoc(),
-        RankedTensorType::get(
-            iota.output_shape().getType().cast<ShapedType>().getShape(),
-            rewriter.getI64Type()),
-        iota.output_shape());
-
     auto slicedShape = rewriter.create<SliceOp>(
-        iota.getLoc(), convertedShape,
+        iota.getLoc(), iota.output_shape(),
         rewriter.getI64TensorAttr(iotaDimensionInt),
         rewriter.getI64TensorAttr(iotaDimensionInt + 1),
         rewriter.getI64TensorAttr(1));

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
@@ -1763,8 +1763,19 @@ struct DynamicIotaBroadcast : public OpRewritePattern<DynamicIotaOp> {
 
     auto iotaDimension = iota.iota_dimension();
     auto iotaDimensionInt = iotaDimension;
+    auto outputShapeType = iota.output_shape().getType().cast<ShapedType>();
+    Value sliceInput = iota.output_shape();
+    if (outputShapeType.getElementType().isa<mlir::IndexType>()) {
+      sliceInput = rewriter.create<arith::IndexCastOp>(
+        iota.getLoc(),
+        RankedTensorType::get(
+          iota.output_shape().getType().cast<ShapedType>().getShape(),
+          rewriter.getI64Type()),
+        iota.output_shape());
+    }
+     
     auto slicedShape = rewriter.create<SliceOp>(
-        iota.getLoc(), iota.output_shape(),
+        iota.getLoc(), sliceInput,
         rewriter.getI64TensorAttr(iotaDimensionInt),
         rewriter.getI64TensorAttr(iotaDimensionInt + 1),
         rewriter.getI64TensorAttr(1));


### PR DESCRIPTION
This PR removed shape cating, if the shape is i32, casting from tensor<2xi32> to tensor<2xi64> emits error, and if the shape is i64, the cast did nothing.

