### PR TITLE
work around compilation error on GCC 7.3.1:

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/mhlo_to_lhlo_with_xla.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/mhlo_to_lhlo_with_xla.cc
@@ -202,7 +202,12 @@ class XlaHloToLhloPass
       TF_RETURN_WITH_CONTEXT_IF_ERROR(
           ConvertMlirHloToHlo(module, &hlo_proto,
                               /*use_tuple_args=*/false,
-                              /*return_tuple=*/false),
+                              // BladeDISC Change starts: to work around
+                              // compilation error on GCC 7.3.1, add the
+                              // options argument.
+                              /*return_tuple=*/false,
+                              /*options=*/{}),
+                              // BladeDISC Change ends.
           "conversion to XLA HLO proto failed");
 
       auto statusOrHloModule = HloModuleFromProto(hlo_proto);


### PR DESCRIPTION
  like: undefined reference to `std::function<tensorflow::StatusOr<xla::Shape> (xla::Shape const&, bool, mlir::XlaLayoutPreference)>::function()'