### PR TITLE
Revert "import iree in workspace file"

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -919,13 +919,6 @@ def _tf_repositories():
         ],
     )
 
-    tf_http_archive(
-        name = "iree-dialects",
-        sha256 = "f6ed70146b85d27c25cb4653cfb879d7954be426516b1cac230cbf5bb8b041da",
-        strip_prefix = "iree-7cd0a8cb6e1027188faa75b9361c4b10aab4707c/llvm-external-projects/iree-dialects",
-        urls = tf_mirror_urls("https://github.com/iree-org/iree/archive/7cd0a8cb6e1027188faa75b9361c4b10aab4707c.zip"),
-    )
-
     # used for adding androidx.annotation dependencies in tflite android jni.
     maven_install(
         artifacts = [


### PR DESCRIPTION
This reverts commit d71e5b32f1b82d4b8adb05dac8772ce80bd7fa58.

disc now has its own top workspace file, thus we'll import iree here instead of inside TF.